### PR TITLE
The HttpClient is now passed to the ConfigurationManager, so that if …

### DIFF
--- a/src/SuperOffice.SystemUserClient/ConfigurationManager.cs
+++ b/src/SuperOffice.SystemUserClient/ConfigurationManager.cs
@@ -76,7 +76,7 @@ namespace SuperOffice.SystemUser
   
             // Have to look into avoiding WebApiOptions parameter here
             _configAgent =
-                new OidcConfigAgent(MetadataAddress);
+                new OidcConfigAgent(MetadataAddress, client);
         }
 
         /// <summary>

--- a/src/SuperOffice.SystemUserClient/OidcConfigAgent.cs
+++ b/src/SuperOffice.SystemUserClient/OidcConfigAgent.cs
@@ -21,13 +21,13 @@ namespace SuperOffice.SystemUser
         {
             _cache = new MemoryCache(new MemoryCacheOptions());
         }
-
-        public OidcConfigAgent(string uri)
+        public OidcConfigAgent(string uri, HttpClient client)
         {
             var retriever = new OpenIdConnectConfigurationRetriever();
             _configManager = new ConfigurationManager<OpenIdConnectConfiguration>(
                 uri,
-                retriever);
+                retriever,
+                client);
         }
 
         internal async Task<OpenIdConnectConfiguration> GetConfigurationAsync(string metadataAddress)


### PR DESCRIPTION
…specified it gets used. 

Issue #9 

Community: https://community.superoffice.com/en/technical/forums/api-forums/client-libraries-and-tools/superoffice.systemuser.client-v1.2-ignores-proxy-on-authentication
